### PR TITLE
Make serenade.rb also work with version 4 of Sprockets.

### DIFF
--- a/lib/serenade/sprockets.rb
+++ b/lib/serenade/sprockets.rb
@@ -1,4 +1,11 @@
 require "serenade/template"
 require "sprockets"
 
-Sprockets.register_engine(".serenade", Serenade::Template)
+if Sprockets.respond_to?(:register_transformer)
+  Sprockets.register_mime_type "text/x-serenade", extensions: [".serenade"]
+  Sprockets.register_preprocessor "text/x-serenade", Serenade::Template
+elsif Sprockets.respond_to?(:register_engine)
+  args = [".serenade", Serenade::Template]
+  args << { silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
+  Sprockets.register_engine(*args)
+end

--- a/serenade.gemspec
+++ b/serenade.gemspec
@@ -22,7 +22,7 @@ TEXT
   gem.add_dependency "execjs", ">= 0.3.0"
   gem.add_dependency "multi_json"
   gem.add_development_dependency "rspec", "~> 2.0"
-  gem.add_development_dependency "sprockets", "~> 2.0"
+  gem.add_development_dependency "sprockets", "~> 4.0.0.beta6"
   gem.add_development_dependency "rails", "~> 3.1"
 
   gem.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Uses the recommended way of checking for Sprockets versions from https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#registering-all-versions-of-sprockets-in-processors